### PR TITLE
Fixing mixed Hebrew and numbers: issue #10

### DIFF
--- a/bidi/algorithm.py
+++ b/bidi/algorithm.py
@@ -503,7 +503,7 @@ def reverse_contiguous_sequence(chars, line_start, line_end, highest_level,
                 else:
                     _end = run_idx
             else:
-                if _end:
+                if _end is not None:
                     chars[_start:+_end+1] = \
                             reversed(chars[_start:+_end+1])
                     _start = _end = None

--- a/tests/test_bidi.py
+++ b/tests/test_bidi.py
@@ -128,6 +128,13 @@ class TestBidiAlgorithm(unittest.TestCase):
                 storage = storage.replace(key, val)
             self.assertEqual(get_display(storage, upper_is_rtl=True), display)
 
+    def test_mixed_hebrew_numbers_issue10(self):
+        tests = (
+            (u'1 2 3 \u05E0\u05D9\u05E1\u05D9\u05D5\u05DF', u'\u05DF\u05D5\u05D9\u05E1\u05D9\u05E0 3 2 1'),
+        )
+        for storage, display in tests:
+            self.assertEqual(get_display(storage), display)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_bidi.py
+++ b/tests/test_bidi.py
@@ -134,6 +134,7 @@ class TestBidiAlgorithm(unittest.TestCase):
         """
         tests = (
             (u'1 2 3 \u05E0\u05D9\u05E1\u05D9\u05D5\u05DF', u'\u05DF\u05D5\u05D9\u05E1\u05D9\u05E0 3 2 1'),
+            (u'1 2 3 123 \u05E0\u05D9\u05E1\u05D9\u05D5\u05DF', u'\u05DF\u05D5\u05D9\u05E1\u05D9\u05E0 123 3 2 1'),
         )
         for storage, display in tests:
             self.assertEqual(get_display(storage), display)

--- a/tests/test_bidi.py
+++ b/tests/test_bidi.py
@@ -129,6 +129,9 @@ class TestBidiAlgorithm(unittest.TestCase):
             self.assertEqual(get_display(storage, upper_is_rtl=True), display)
 
     def test_mixed_hebrew_numbers_issue10(self):
+        """Test for the case reported in
+        https://github.com/MeirKriheli/python-bidi/issues/10
+        """
         tests = (
             (u'1 2 3 \u05E0\u05D9\u05E1\u05D9\u05D5\u05DF', u'\u05DF\u05D5\u05D9\u05E1\u05D9\u05E0 3 2 1'),
         )


### PR DESCRIPTION
I'm fairly sure this fixes #10. The `_end` variable was test for "true", but ic can legitimately be 0 here, so it should be tested against None instead.