### PR TITLE
Change assert to implicit type checking

### DIFF
--- a/bidi/algorithm.py
+++ b/bidi/algorithm.py
@@ -461,22 +461,18 @@ def resolve_implicit_levels(storage, debug):
         chars = storage['chars'][start:start+length]
 
         for _ch in chars:
-            # only those types are allowed at this stage
-            assert _ch['type'] in ('L', 'R', 'EN', 'AN'),\
-                    '%s not allowed here' % _ch['type']
-
             if _embedding_direction(_ch['level']) == 'L':
                 # I1. For all characters with an even (left-to-right) embedding
                 # direction, those of type R go up one level and those of type
                 # AN or EN go up two levels.
                 if _ch['type'] == 'R':
                     _ch['level'] += 1
-                elif _ch['type'] != 'L':
+                elif _ch['type'] in ('EN', 'AN'):
                     _ch['level'] += 2
             else:
                 # I2. For all characters with an odd (right-to-left) embedding
                 # direction, those of type L, EN or AN  go up one level.
-                if _ch['type'] != 'R':
+                if _ch['type'] in ('L', 'EN', 'AN'):
                     _ch['level'] += 1
 
     if debug:


### PR DESCRIPTION
Better to use implicit type checking rather using assert, which will breaks the application if the character type not just L, R, AN, or EN.
For example \u2069 which is PDI, or \u2067 which is RLI.