### PR TITLE
Remove all six usage and thus remove Python 2 support

### DIFF
--- a/bidi/__init__.py
+++ b/bidi/__init__.py
@@ -32,7 +32,6 @@ def main():
     import sys
     import codecs
     import locale
-    import six
     from .algorithm import get_display
 
     parser = optparse.OptionParser()
@@ -67,10 +66,6 @@ def main():
     if options.base_dir and options.base_dir not in 'LR':
         parser.error('option -b can be L or R')
 
-    # allow unicode in sys.stdout.write
-    if six.PY2:
-        sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout)
-
     if rest:
         lines = rest
     else:
@@ -80,7 +75,7 @@ def main():
         display = get_display(line, options.encoding, options.upper_is_rtl,
                               options.base_dir, options.debug)
         # adjust the encoding as unicode, to match the output encoding
-        if not isinstance(display, six.text_type):
+        if not isinstance(display, str):
             display = display.decode(options.encoding)
 
-        six.print_(display, end='')
+        print(display, end='')

--- a/bidi/algorithm.py
+++ b/bidi/algorithm.py
@@ -21,7 +21,6 @@ import sys
 import inspect
 from collections import deque
 from unicodedata import bidirectional, mirrored
-import six
 
 from .mirror import MIRRORED
 
@@ -66,10 +65,7 @@ def debug_storage(storage, base_info=False, chars=True, runs=False):
     import locale
     import sys
 
-    if six.PY2:
-        stderr = codecs.getwriter(locale.getpreferredencoding())(sys.stderr)
-    else:
-        stderr = sys.stderr
+    stderr = sys.stderr
 
     caller = inspect.stack()[1][3]
     stderr.write('in %s\n' % caller)
@@ -91,7 +87,7 @@ def debug_storage(storage, base_info=False, chars=True, runs=False):
         stderr.write(output + u'\n')
 
         output = u'  Res. levels : %s\n' % u''.join(
-            [six.text_type(_ch['level']) for _ch in storage['chars']])
+            [str(_ch['level']) for _ch in storage['chars']])
         stderr.write(output)
 
         _types = [_ch['type'].ljust(3) for _ch in storage['chars']]
@@ -626,7 +622,7 @@ def get_display(unicode_or_str, encoding='utf-8', upper_is_rtl=False,
     storage = get_empty_storage()
 
     # utf-8 ? we need unicode
-    if isinstance(unicode_or_str, six.text_type):
+    if isinstance(unicode_or_str, str):
         text = unicode_or_str
         decoded = False
     else:

--- a/setup.py
+++ b/setup.py
@@ -10,17 +10,13 @@ except ImportError:
 readme = open('README.rst').read()
 history = open('CHANGELOG.rst').read().replace('.. :changelog:', '')
 
-requirements = [
-    'six'
-]
-
 test_requirements = [
     # TODO: put package test requirements here
 ]
 
 setup(
     name="python-bidi",
-    version="0.4.1",
+    version="0.4.3",
     url='https://github.com/MeirKriheli/python-bidi',
     description='Pure python implementation of the BiDi layout algorithm',
     long_description=readme + '\n\n' + history,
@@ -46,9 +42,6 @@ setup(
         'Operating System :: OS Independent',
         'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
         'Topic :: Text Processing',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',

--- a/tests/test_bidi.py
+++ b/tests/test_bidi.py
@@ -18,7 +18,6 @@
 """BiDi algorithm unit tests"""
 
 import unittest
-import six
 from bidi.algorithm import get_display, get_empty_storage, get_embedding_levels
 
 
@@ -85,8 +84,8 @@ class TestBidiAlgorithm(unittest.TestCase):
     def test_output_encoding(self):
         """Make sure the display is in the same encoding as the incoming text"""
 
-        storage = six.b('\xf9\xec\xe5\xed')  # Hebrew word shalom in cp1255
-        display = six.b('\xed\xe5\xec\xf9')
+        storage = b'\xf9\xec\xe5\xed'  # Hebrew word shalom in cp1255
+        display = b'\xed\xe5\xec\xf9'
 
         self.assertEqual(get_display(storage, encoding='cp1255'), display)
 


### PR DESCRIPTION
Python 2 has been EOL for quite a while now, there is no need to support it anymore.

In my case this removes the only dependency on six in a project I'm working on and shaves off quite a bit of CI time (installing six can take quite a while...).