### PR TITLE
Modernize and simplify Python code

### DIFF
--- a/bidi/__init__.py
+++ b/bidi/__init__.py
@@ -61,10 +61,7 @@ def main():
 
     options, rest = parser.parse_known_args()
 
-    if rest:
-        lines = rest
-    else:
-        lines = sys.stdin
+    lines = rest or sys.stdin
 
     for line in lines:
         display = get_display(

--- a/bidi/algorithm.py
+++ b/bidi/algorithm.py
@@ -1,6 +1,6 @@
 from typing import AnyStr, Optional
 
-from .bidi import get_display_inner, get_base_level_inner
+from .bidi import get_base_level_inner, get_display_inner
 
 
 def get_display(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
 # complexity documentation build configuration file, created by
 # sphinx-quickstart on Tue Jul  9 22:26:36 2013.
@@ -13,8 +12,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another
 # directory, add these directories to sys.path here. If the directory is
@@ -55,8 +54,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Python BiDi'
-copyright = u'2014, Meir Kriheli'
+project = 'Python BiDi'
+copyright = '2014, Meir Kriheli'
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -209,8 +208,8 @@ latex_elements = {
 # [howto/manual]).
 latex_documents = [
     ('index', 'python-bidi.tex',
-     u'Python BiDi Documentation',
-     u'Meir Kriheli', 'manual'),
+     'Python BiDi Documentation',
+     'Meir Kriheli', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at
@@ -240,8 +239,8 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'python-bidi',
-     u'Python BiDi Documentation',
-     [u'Meir Kriheli'], 1)
+     'Python BiDi Documentation',
+     ['Meir Kriheli'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -255,8 +254,8 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     ('index', 'python-bidi',
-     u'Python BiDi Documentation',
-     u'Meir Kriheli',
+     'Python BiDi Documentation',
+     'Meir Kriheli',
      'python-bidi',
      'One line description of project.',
      'Miscellaneous'),


### PR DESCRIPTION
Let's clean up some Python 2 artifacts with a Python linter built in Rust: https://docs.astral.sh/ruff

% `ruff check --select=I001,SIM108,UP --target-version=py39 --statistics`
```
8	UP025 	[*] unicode-kind-prefix
2	I001  	[*] unsorted-imports
1	SIM108	[*] if-else-block-instead-of-if-exp
1	UP009 	[*] utf8-encoding-declaration
```
% `ruff check --select=I001,SIM108,UP --target-version=py39 --fix --unsafe-fixes`
```
Found 12 errors (12 fixed, 0 remaining).
```
% `ruff rule UP025`
# unicode-kind-prefix (UP025)

Derived from the **pyupgrade** linter.

Fix is always available.

## What it does
Checks for uses of the Unicode kind prefix (`u`) in strings.

## Why is this bad?
In Python 3, all strings are Unicode by default. The Unicode kind prefix is
unnecessary and should be removed to avoid confusion.

## Example
```python
u"foo"
```

Use instead:
```python
"foo"
```

## References
- [Python documentation: Unicode HOWTO](https://docs.python.org/3/howto/unicode.html)
