### PR TITLE
CI: Add python3.14 builds for linux

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,7 +46,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i 3.8 3.9 3.10 3.11 3.12 3.13 pypy3.11
+          args: --release --out dist -i 3.8 3.9 3.10 3.11 3.12 3.13 3.14 pypy3.11
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels


### PR DESCRIPTION
In commit 076d457 python3.14 builds were added to CI for most platforms, however it appears that `linux` was accidentally missed.

Note: This was presenting to me as a failure to build the rust components due to some Cargo version mismatch. I don't know enough about rust to diagnose that, but having a binary wheel would resolve that problem form me.

```
Collecting python-bidi
  Using cached python_bidi-0.6.7.tar.gz (45 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [10 lines of output]
      error: failed to parse lock file at: /tmp/pip-install-19sctyza/python-bidi_6564aba3260745d295309716abc47cae/Cargo.lock
      
      Caused by:
        lock file version `4` was found, but this version of Cargo does not understand this lock file, perhaps Cargo needs to be updated?
      💥 maturin failed
        Caused by: Cargo metadata failed. Does your crate compile with `cargo build`?
        Caused by: `cargo metadata` exited with an error:
      Error running maturin: Command '['maturin', 'pep517', 'write-dist-info', '--metadata-directory', '/tmp/pip-modern-metadata-fq_tyueh', '--interpreter', '/home/user/vid/ocr/venv/bin/python']' returned non-zero exit status 1.
      Checking for Rust toolchain....
      Running `maturin pep517 write-dist-info --metadata-directory /tmp/pip-modern-metadata-fq_tyueh --interpreter /home/user/vid/ocr/venv/bin/python`
      [end of output]
```